### PR TITLE
SEO-204825-Angular-Description-Too-Short-Hotfix

### DIFF
--- a/aspnet-core/DataManager/CRUDDataOperations.md
+++ b/aspnet-core/DataManager/CRUDDataOperations.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: CRUD Data Operations | DataManager | ASP.NET Core | Syncfusion
-description: CRUD Data Operations
+description: Check out and learn here all about CRUD data operations of Syncfusion ASP.NET Core DataManager and much more.
 platform: aspnet-core
 control: DataManager
 documentation: ug
@@ -85,7 +85,7 @@ The insert method of the data manager is used to add a new record to the table. 
 
 {% endtabs %}
 
-![](CRUD_images/insert1.png) 
+![Local CRUD Operations in Insert.](CRUD_images/insert1.png) 
 
 ### Update
 
@@ -154,7 +154,7 @@ The update method is used to update the modified changes made to a record in the
 
 {% endtabs %}
 
-![](CRUD_images/update1.png) 
+![Local CRUD Operations in Update.](CRUD_images/update1.png) 
 
 ### Remove
 
@@ -223,7 +223,7 @@ The remove function receives the items to be deleted in the Data Table. The func
 
 {% endtabs %}
 
-![](CRUD_images/remove1.png) 
+![Local CRUD Operations in Remove.](CRUD_images/remove1.png) 
 
 ## Remote CRUD Operations
 
@@ -311,7 +311,7 @@ The insert method of the data manager is used to add a new record to the table. 
 
 {% endtabs %}
 
-![](CRUD_images/insert2.png) 
+![Remote CRUD Operations in Insert.](CRUD_images/insert2.png) 
 
 ### Update
 

--- a/aspnet-core/Spreadsheet/Rows-and-columns.md
+++ b/aspnet-core/Spreadsheet/Rows-and-columns.md
@@ -1,7 +1,7 @@
 ---
 layout: post
-title: Rows and Columns with Spreadsheet widget for Syncfusion Essential ASP.NET Core
-description: How to use and customize the Spreadsheet Rows and Columns
+title: Rows and Columns with Spreadsheet widget for Syncfusion ASP.NET Core
+description: Check out and learn here all about how to use and customize the spreadsheet rows and columns and much more.
 platform: aspnet-core
 control: Spreadsheet
 documentation: ug
@@ -263,7 +263,7 @@ namespace MVCSampleBrowser.Controllers
 {% endtabs %}
 
 The following output is displayed as a result of the above code example.
-![](Rows-and-columns_images/Rows-and-columns_img2.png)
+![Delete Entire Column in Spreadsheet.](Rows-and-columns_images/Rows-and-columns_img2.png)
 
 ### Show Row
 You can show the hidden rows dynamically by using one of the following ways,
@@ -324,7 +324,7 @@ namespace MVCSampleBrowser.Controllers
 {% endtabs %}
 
 The following output is displayed as a result of the above code example.
-![](Rows-and-columns_images/Rows-and-columns_img3.png)
+![Hide Column in Spreadsheet.](Rows-and-columns_images/Rows-and-columns_img3.png)
 
 ## Resizing
 You can change `column-width` and `row-height` with the specified value. You have to enable `allow-resizing` property to perform resizing.
@@ -380,4 +380,4 @@ namespace MVCSampleBrowser.Controllers
 {% endtabs %}
 
 The following output is displayed as a result of the above code example.
-![](Rows-and-columns_images/Rows-and-columns_img4.png)
+![Show Column inSpreadsheet.](Rows-and-columns_images/Rows-and-columns_img4.png)


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Description too short|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/204825/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BB8ADF1C8-2C7B-4694-B521-1AEC03ECA949%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Meta description| Meta description was too short. SEO rule says it should be 100+ characters, so I changed it.|
|Add the image alt tag | Image alt tag missing, so i add it|


Regards, 
Asha