### PR TITLE
seo-205214-ASP.NET Core-H1-tag-Missing-hotfix

### DIFF
--- a/aspnet-core/Chart/Chart-Dimensions.md
+++ b/aspnet-core/Chart/Chart-Dimensions.md
@@ -39,7 +39,7 @@ You can also set the chart dimension by using the **Size** property of the chart
 
 {% endhighlight %}
 
-![](Chart-Dimensions_images/Chart-Dimensions_img1.png)
+![set size in pixels in ASP.Net Core Chart.](Chart-Dimensions_images/Chart-Dimensions_img1.png)
 
 ## Setting size relative to the container size
 
@@ -56,7 +56,7 @@ You can specify the chart size in percentage by using the **Size** property. The
 
 {% endhighlight %}
 
-![](Chart-Dimensions_images/Chart-Dimensions_img2.png)
+![setting size relative to the container size in ASP.NET Core Chart.](Chart-Dimensions_images/Chart-Dimensions_img2.png)
 
 
 ## Responsive chart

--- a/aspnet-core/DropDownList/Customization.md
+++ b/aspnet-core/DropDownList/Customization.md
@@ -47,9 +47,9 @@ It provides the short description of the expected value in dropdown and will dis
     
 {% endtabs %}
 
-![](Customization_images/Customization_img1.png)
+![adding watermark text in customization.](Customization_images/Customization_img1.png)
 
-![](Customization_images/Customization_img2.png)
+![Adding watermark text in ASP.NET Core Drop Down List.](Customization_images/Customization_img2.png)
 
 ## Applying Rounded Corner
 
@@ -129,7 +129,7 @@ The Enabled property is used to indicate whether the control can respond to the 
     
 {% endtabs %}
 
-![](Customization_images/Customization_img4.png)
+![enable/disable the control in ASP.NET Drop Down List.](Customization_images/Customization_img4.png)
 
 ## Applying HTML Attributes
 
@@ -173,4 +173,4 @@ Additional HTML attributes can be applied to the control by using HtmlAttributes
     
 {% endtabs %}
 
-![](Customization_images/Customization_img5.png)
+![applying html attributes in ASP.NET Core.](Customization_images/Customization_img5.png)

--- a/aspnet-core/RichTextEditor/ImportAndExport.md
+++ b/aspnet-core/RichTextEditor/ImportAndExport.md
@@ -7,7 +7,7 @@ control: RTE
 documentation: ug
 ---
 
-## Import 
+# Import 
 
 Import feature provides support to import a word document into the editor `textarea`. To enable import option in the RTE tool bar,  `import` toolbar items needs to be added in RTE toolbar toolsList using `importExport` which adds the tool in the toolbar. In `ImportSettings` Url option, the server page for import is needed to be mapped. When you click the toolbar import icon, it opens a dialog to browse the select a word file. The selected word file will be imported into the editor `textarea`.
 

--- a/aspnet-core/SpellCheck/Functionalities.md
+++ b/aspnet-core/SpellCheck/Functionalities.md
@@ -249,7 +249,7 @@ The following code example describes the above behavior.
 
 The following screenshot displays the output for the above code
 
-![](ValidateOnType_Images/validateontype.png)
+![checking content on typing in ASP.NET Core Spellcheck.](ValidateOnType_Images/validateontype.png)
 
 ## Suggestion Words
 

--- a/aspnet-core/TreeView/Full-Row-Selection.md
+++ b/aspnet-core/TreeView/Full-Row-Selection.md
@@ -75,7 +75,7 @@ In the view page, add the following code and map the properties defined to the c
 {% endhighlight %}
 
 By running the previous code, you will get the output like the following:
-![](Fullrowselection_images/selection1.png)
+![full row selection in ASP.NET Tree view.](Fullrowselection_images/selection1.png)
 
 ## Customization
 
@@ -189,4 +189,4 @@ In the view page, add the following code and map the properties defined to the c
 {% endhighlight %}
 
 By running the above code, you will get the output like the following:
-![](Fullrowselection_images/custom.png)
+![customize in ASP>NET COre Tree View.](Fullrowselection_images/custom.png)


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/205214/|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B13A50D72-C3C5-4635-90F2-E36DE3A8B07C%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |




Regards, 
Asha