### PR TITLE
SEO-206704-ASP.NET Core-H1-tag-Missing-hotfix

### DIFF
--- a/aspnet-core/RichTextEditor/ImportAndExport.md
+++ b/aspnet-core/RichTextEditor/ImportAndExport.md
@@ -7,7 +7,7 @@ control: RTE
 documentation: ug
 ---
 
-## Import 
+# Import 
 
 Import feature provides support to import a word document into the editor `textarea`. To enable import option in the RTE tool bar,  `import` toolbar items needs to be added in RTE toolbar toolsList using `importExport` which adds the tool in the toolbar. In `ImportSettings` Url option, the server page for import is needed to be mapped. When you click the toolbar import icon, it opens a dialog to browse the select a word file. The selected word file will be imported into the editor `textarea`.
 
@@ -32,7 +32,7 @@ Import feature provides support to import a word document into the editor `texta
 
 {% endhighlight %}
 
-![](ImportAndExport_images/import_images.png)
+![import a word document into the editor textarea.](ImportAndExport_images/import_images.png)
 
 ## Export 
 
@@ -62,7 +62,7 @@ Export feature provides support to export editor `textarea` content into word an
 {% endhighlight %}
 
 ### Word Export
-![](ImportAndExport_images/export_word_images.png)
+![export feature provides support to export editor textarea content into word.](ImportAndExport_images/export_word_images.png)
 
 ### PDF Export
-![](ImportAndExport_images/export_pdf_images.png)
+![export feature provides support to export editor textarea content into pdf.](ImportAndExport_images/export_pdf_images.png)


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |H1 Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/206704|
|Share point | [Share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7BC1479F0A-9619-4A7C-B47E-C05E2DB08DD9%7D&file=help%20syncfusion.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Change h1 tag | One page should have only one H1 tag as per SEO rules, so I changed it. |
|Update the image alt tag| The image alt tag is important for SEO, so I updated it.|




Regards, 
Asha