### PR TITLE
SEO-206704-Image-Alt-Missing-ASP.NET Core-Hotfix

### DIFF
--- a/aspnet-core/Grid/Selection.md
+++ b/aspnet-core/Grid/Selection.md
@@ -65,7 +65,7 @@ The following code example describes the above behavior.
 
 The following output is displayed as a result of the above code example
 
-![](Selection_images/Selection_img1.png)
+![row selection in Grid.](Selection_images/Selection_img1.png)
 
 ## Multiple row selection using checkbox column
 
@@ -107,7 +107,7 @@ The following code example describes the above behavior.
 
 The following output is displayed as a result of the above code example
 
-![](Selection_images/Selection_img12.png)
+![multiple row selection using checkbox column in ASP.NET Core Grid.](Selection_images/Selection_img12.png)
 
 ## Cell selection
 
@@ -150,7 +150,7 @@ The following code example describes the above behavior.
 
 The following output is displayed as a result of the above code example
 
-![](Selection_images/Selection_img2.png)
+![cell selection in ASP.NET Core Grid.](Selection_images/Selection_img2.png)
 
 ### Cell selection mode
 
@@ -196,7 +196,7 @@ The following code example describes the above behavior.
 
  The following output is displayed as a result of the above code example
 
-![](Selection_images/Selection_img3.png)
+![cell selection mode in ASP.NET Core Grid.](Selection_images/Selection_img3.png)
 
 
 ## Column selection
@@ -239,7 +239,7 @@ The following code example describes the above behavior.
 
 The following output is displayed as a result of the above code example
 
-![](Selection_images/Selection_img4.png)
+![column selection in ASP.NET Core Grid.](Selection_images/Selection_img4.png)
 
 
 ## Touch options
@@ -280,7 +280,7 @@ The following code example describes the above behavior.
 
 The following output is displayed as a result of the above code example.
 
-![](Selection_images/Selection_img5.png)
+![touch options in ASP.NET Core Grid.](Selection_images/Selection_img5.png)
 
 
 ## Toggle selection
@@ -364,4 +364,4 @@ The following code example describes the above behavior.
 
 The following output is displayed as a result of the above code example.
 
-![](selection_images/Selection_img13.png)
+![drag selection in ASP.NET Core Grid.](selection_images/Selection_img13.png)

--- a/aspnet-core/Schedule/Getting-Started.md
+++ b/aspnet-core/Schedule/Getting-Started.md
@@ -134,7 +134,7 @@ Now, define the action _GetData_ within the **Home** controller page as shown be
 {% endhighlight %}
 
 
-![](Getting-Started_images/Getting-Started_img1.png)
+![getting started in ASP.NET Core Schedule.](Getting-Started_images/Getting-Started_img1.png)
 
 
  

--- a/aspnet-core/TreeView/Checkboxes.md
+++ b/aspnet-core/TreeView/Checkboxes.md
@@ -24,7 +24,7 @@ The tree view supports tri-state checkboxes in addition to the standard two-stat
     {% endhighlight %}
     
 By running the above code, you will get the output like the following image.
-![](Checkboxes_images/checkbox_images_img1.png)
+![indeterminate checkboxes in ASP.NET Core TreeView](Checkboxes_images/checkbox_images_img1.png)
 
 ## Auto checkable
 

--- a/aspnet-core/TreeView/Populate-Data.md
+++ b/aspnet-core/TreeView/Populate-Data.md
@@ -620,12 +620,12 @@ In the view page, add the following code and map the properties defined to the c
 
 The following screenshot displays the load on demand for a local data source in the tree view control.
 
-![](Populate-Data_images/Populate-Data_img1.png)
+![expanding the parent node in ASP.NET Core TreeView.](Populate-Data_images/Populate-Data_img1.png)
 
 While expanding the parent node
 {:.caption}
 
-![](Populate-Data_images/Populate-Data_img2.png)
+![After expanding the parent node in ASP.NET Core TreeView.](Populate-Data_images/Populate-Data_img2.png)
 
 After expanding the parent node
 {:.caption}


### PR DESCRIPTION
Hi @MallikaRK 

Title | Description
-- | --
|Task Category |Image Alt Tag Missing|
|Ticket/Task link| https://dev.azure.com/Syncfusion-Infrastructure/Syncfusion%20SEO/_workitems/edit/206704/|
|Share point| [share point](https://syncfusion.sharepoint.com/:x:/r/sites/SEOWebsiteAuditing/_layouts/15/Doc.aspx?sourcedoc=%7B425BC1DA-899F-43C9-83EC-59BDC2E6D2D3%7D&file=Bing%20Issues%20-%20SEO.xlsx&action=default&mobileredirect=true)|



Changes Made | Reason for change |
|-- | -- |
|Update the img alt tag|The image alt tag is important for SEO, so I updated it.|





Regards, 
Asha